### PR TITLE
Fix link to sponspors page

### DIFF
--- a/docs/insiders.md
+++ b/docs/insiders.md
@@ -13,7 +13,7 @@ You can become a sponsor using your individual or organization's GitHub account.
 Then, after a few hours, you will be added as a team member to the super-secret private GitHub repository containing the Insiders edition, which has all exclusive features.
 In addition, you get access to Insiders-only team discussions and content.
 
-> :information_source: **Important**: If you're sponsoring [RaspAP](https://github.com/RaspAP/sponsors) through a GitHub organization, please send a short email to [sponsors@raspap.com](mailto:sponsors@raspap.com) with the name of your organization and the account that should be added as a collaborator.[^2] 
+> :information_source: **Important**: If you're sponsoring [RaspAP](https://github.com/sponsors/RaspAP) through a GitHub organization, please send a short email to [sponsors@raspap.com](mailto:sponsors@raspap.com) with the name of your organization and the account that should be added as a collaborator.[^2] 
 
 You can cancel your sponsorship anytime.[^3]
 


### PR DESCRIPTION
The original link was to GitHub repo that doesn't exist -> 404 page